### PR TITLE
Fix #8: fix the xss deficiency

### DIFF
--- a/finances.js
+++ b/finances.js
@@ -1,3 +1,17 @@
+// HTML 防注入转义函数
+function escapeHTML(str) {
+    if (typeof str !== 'string') return str;
+    return str.replace(/[&<>'"]/g, function(tag) {
+        const charsToReplace = {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            "'": '&#39;',
+            '"': '&quot;'
+        };
+        return charsToReplace[tag] || tag;
+    });
+}
 
 function openSidebar() {
     var side = document.getElementById('sidebar');
@@ -135,10 +149,9 @@ function renderTransactions(transactions) {
         transactionRow.innerHTML = `
             <td>${transaction.trID}</td>
             <td>${transaction.trDate}</td>
-            <td>${transaction.trCategory}</td>
+            <td>${escapeHTML(transaction.trCategory)}</td>
             <td class="tr-amount">${formattedAmount}</td>
-            <td>${transaction.trNotes}</td>
-            <td class="action">
+            <td>${escapeHTML(transaction.trNotes)}</td> <td class="action">
                 <i title="Edit" onclick="editRow('${transaction.trID}')" class="edit-icon fa-solid fa-pen-to-square"></i>
                 <i onclick="deleteTransaction('${transaction.trID}')" class="delete-icon fas fa-trash-alt"></i>
             </td> 

--- a/finances.js
+++ b/finances.js
@@ -1,4 +1,3 @@
-// HTML 防注入转义函数
 function escapeHTML(str) {
     if (typeof str !== 'string') return str;
     return str.replace(/[&<>'"]/g, function(tag) {

--- a/finances.js
+++ b/finances.js
@@ -1,3 +1,4 @@
+"HTML anti-injection function"
 function escapeHTML(str) {
     if (typeof str !== 'string') return str;
     return str.replace(/[&<>'"]/g, function(tag) {

--- a/orders.js
+++ b/orders.js
@@ -1,4 +1,3 @@
-// HTML 防注入转义函数
 function escapeHTML(str) {
     if (typeof str !== 'string') return str;
     return str.replace(/[&<>'"]/g, function(tag) {
@@ -184,7 +183,6 @@ function renderOrders(orders) {
       const formattedTotal = typeof order.orderTotal === 'number' ? `$${order.orderTotal.toFixed(2)}` : '';
 
       
-      // 修改 orders.js 第 165 行附近
       orderRow.innerHTML = `
           <td>${escapeHTML(order.orderID)}</td>
           <td>${order.orderDate}</td>

--- a/orders.js
+++ b/orders.js
@@ -1,3 +1,17 @@
+// HTML 防注入转义函数
+function escapeHTML(str) {
+    if (typeof str !== 'string') return str;
+    return str.replace(/[&<>'"]/g, function(tag) {
+        const charsToReplace = {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            "'": '&#39;',
+            '"': '&quot;'
+        };
+        return charsToReplace[tag] || tag;
+    });
+}
 
 function openSidebar() {
     var side = document.getElementById('sidebar');
@@ -169,21 +183,22 @@ function renderOrders(orders) {
       const formattedTaxes = typeof order.taxes === 'number' ? `$${order.taxes.toFixed(2)}` : '';
       const formattedTotal = typeof order.orderTotal === 'number' ? `$${order.orderTotal.toFixed(2)}` : '';
 
+      
+      // 修改 orders.js 第 165 行附近
       orderRow.innerHTML = `
-        <td>${order.orderID}</td>
-        <td>${order.orderDate}</td>
-        <td>${order.itemName}</td>
-        <td>${formattedPrice}</td>
-        <td>${order.qtyBought}</td>
-        <td>${formattedShipping}</td>
-        <td>${formattedTaxes}</td>
-        <td class="order-total">${formattedTotal}</td>
-        <td>
-            <div class="status ${statusMap[order.orderStatus]}"><span>${order.orderStatus}</span></div>
-        </td>
-        <td class="action">
-            <i title="Edit" onclick="editRow('${order.orderID}')" class="edit-icon fa-solid fa-pen-to-square"></i>
-            <i onclick="deleteOrder('${order.orderID}')" class="delete-icon fas fa-trash-alt"></i>
+          <td>${escapeHTML(order.orderID)}</td>
+          <td>${order.orderDate}</td>
+          <td>${escapeHTML(order.itemName)}</td> <td>${formattedPrice}</td>
+          <td>${order.qtyBought}</td>
+          <td>${formattedShipping}</td>
+          <td>${formattedTaxes}</td>
+          <td class="order-total">${formattedTotal}</td>
+          <td>
+             <div class="status ${statusMap[order.orderStatus]}"><span>${escapeHTML(order.orderStatus)}</span></div>
+          </td>
+          <td class="action">
+              <i title="Edit" onclick="editRow('${escapeHTML(order.orderID)}')" class="edit-icon fa-solid fa-pen-to-square"></i>
+              <i onclick="deleteOrder('${escapeHTML(order.orderID)}')" class="delete-icon fas fa-trash-alt"></i>
           </td> 
       `;
       orderTableBody.appendChild(orderRow);

--- a/orders.js
+++ b/orders.js
@@ -1,3 +1,4 @@
+"HTML anti-injection function"
 function escapeHTML(str) {
     if (typeof str !== 'string') return str;
     return str.replace(/[&<>'"]/g, function(tag) {

--- a/products.js
+++ b/products.js
@@ -1,4 +1,3 @@
-// HTML 防注入转义函数
 function escapeHTML(str) {
     if (typeof str !== 'string') return str;
     return str.replace(/[&<>'"]/g, function(tag) {

--- a/products.js
+++ b/products.js
@@ -1,3 +1,17 @@
+// HTML 防注入转义函数
+function escapeHTML(str) {
+    if (typeof str !== 'string') return str;
+    return str.replace(/[&<>'"]/g, function(tag) {
+        const charsToReplace = {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            "'": '&#39;',
+            '"': '&quot;'
+        };
+        return charsToReplace[tag] || tag;
+    });
+}
 
 function openSidebar() {
   var side = document.getElementById('sidebar');
@@ -135,15 +149,14 @@ function renderProducts(products) {
       prodRow.dataset.prodSold = product.prodSold;
 
       prodRow.innerHTML = `
-          <td>${product.prodID}</td>
-          <td>${product.prodName}</td>
-          <td>${product.prodDesc}</td>
-          <td>${product.prodCat}</td>
+          <td>${escapeHTML(product.prodID)}</td>
+          <td>${escapeHTML(product.prodName)}</td>
+          <td>${escapeHTML(product.prodDesc)}</td> <td>${escapeHTML(product.prodCat)}</td>
           <td>$${product.prodPrice.toFixed(2)}</td>
           <td>${product.prodSold}</td>
           <td class="action">
-            <i title="Edit" onclick="editRow('${product.prodID}')" class="edit-icon fa-solid fa-pen-to-square"></i>
-            <i onclick="deleteProduct('${product.prodID}')" class="delete-icon fas fa-trash-alt"></i>
+          <i title="Edit" onclick="editRow('${escapeHTML(product.prodID)}')" class="edit-icon fa-solid fa-pen-to-square"></i>
+          <i onclick="deleteProduct('${escapeHTML(product.prodID)}')" class="delete-icon fas fa-trash-alt"></i>
           </td>
       `;
       prodTableBody.appendChild(prodRow);

--- a/products.js
+++ b/products.js
@@ -1,3 +1,4 @@
+"HTML anti-injection function"
 function escapeHTML(str) {
     if (typeof str !== 'string') return str;
     return str.replace(/[&<>'"]/g, function(tag) {


### PR DESCRIPTION
缺陷分析：在 finances.js、orders.js 和 products.js 中，您使用了模板字符串包裹变量并直接赋值给 .innerHTML。如果用户在“备注 (Notes)”或“产品描述 (Description)”中输入类似 <script>alert(1)</script> 或 <img src=x onerror=alert(1)> 的恶意代码，浏览器会直接执行。

修复方案：引入一个 HTML 转义（Escape）工具函数，在将用户输入的字符串插入 .innerHTML 之前，将其中的危险字符转义为安全的 HTML 实体。

After: <img width="822" height="524" alt="截屏2026-04-27 23 02 35" src="https://github.com/user-attachments/assets/60a6fe3b-ddd7-4159-881b-5acd3708265b" />
<img width="520" height="479" alt="截屏2026-04-27 23 24 08" src="https://github.com/user-attachments/assets/ba816fdc-fd72-4449-824d-ff9eaffcd14d" />
<img width="535" height="472" alt="截屏2026-04-27 23 24 19" src="https://github.com/user-attachments/assets/458f239d-f192-4448-a888-15e205a84882" />


Before: <img width="836" height="382" alt="截屏2026-04-27 23 02 44" src="https://github.com/user-attachments/assets/65b280d9-cd45-49bd-a201-72f2fa6ab950" />
<img width="514" height="528" alt="截屏2026-04-27 23 24 57" src="https://github.com/user-attachments/assets/0563a596-d305-4ea0-8bb9-088559ff2a76" />



Part of #8
