### PR TITLE
Fix #8: fix the xss deficiency

### DIFF
--- a/finances.js
+++ b/finances.js
@@ -304,12 +304,15 @@ function renderTransactions(transactions) {
         const formattedAmount = typeof transaction.trAmount === 'number' ? `$${transaction.trAmount.toFixed(2)}` : '';
         const translatedCategory = translateCategory(transaction.trCategory);
 
+        // 【新增】对用户输入的备注进行 XSS 净化
+        const safeNotes = window.escapeHTML(transaction.trNotes);
+
         transactionRow.innerHTML = `
             <td>${transaction.trID}</td>
             <td>${transaction.trDate}</td>
             <td>${translatedCategory}</td>
             <td class="tr-amount">${formattedAmount}</td>
-            <td>${transaction.trNotes}</td>
+            <td>${safeNotes}</td>
             <td class="action">
                 <i title="Edit" onclick="editRow('${transaction.trID}')" class="edit-icon fa-solid fa-pen-to-square"></i>
                 <i onclick="deleteTransaction('${transaction.trID}')" class="delete-icon fas fa-trash-alt"></i>

--- a/history.js
+++ b/history.js
@@ -161,9 +161,11 @@ function formatData(data) {
   }
 
   const lines = Object.entries(data).map(([key, value]) => {
-    const formattedValue =
+     const rawStringValue =
       typeof value === "object" && value !== null ? JSON.stringify(value) : translateCellValue(key, value);
-    return `<div><span class="log-key">${translateFieldKey(key)}</span>: ${formattedValue}</div>`;
+      // 2. 【新增】进行 XSS 转义包装
+    const safeValue = window.escapeHTML(rawStringValue);
+    return `<div><span class="log-key">${translateFieldKey(key)}</span>: ${safeValue}</div>`;
   });
 
   return `<div class="log-data">${lines.join("")}</div>`;
@@ -196,16 +198,21 @@ function formatComparableData(beforeData, afterData, entity) {
 
   const beforeLines = orderedKeys.map((key) => {
     const value = key in beforeObj ? beforeObj[key] : "-";
-    const formattedValue =
-      typeof value === "object" && value !== null ? JSON.stringify(value) : translateCellValue(key, value);
-    return `<div><span class="log-key">${translateFieldKey(key)}</span>: ${formattedValue}</div>`;
+    // 先转换为字符串
+    const rawStringValue = typeof value === "object" && value !== null ? JSON.stringify(value) : translateCellValue(key, value);
+    // 【新增】再进行转义
+    const safeValue = window.escapeHTML(rawStringValue);
+    return `<div><span class="log-key">${translateFieldKey(key)}</span>: ${safeValue}</div>`;
   });
 
   const afterLines = orderedKeys.map((key) => {
     const value = key in afterObj ? afterObj[key] : "-";
-    const formattedValue =
-      typeof value === "object" && value !== null ? JSON.stringify(value) : translateCellValue(key, value);
-    return `<div><span class="log-key">${translateFieldKey(key)}</span>: ${formattedValue}</div>`;
+
+    // 先转换为字符串
+    const rawStringValue = typeof value === "object" && value !== null ? JSON.stringify(value) : translateCellValue(key, value);
+    // 【新增】再进行转义
+    const safeValue = window.escapeHTML(rawStringValue);
+    return `<div><span class="log-key">${translateFieldKey(key)}</span>: ${safeValue}</div>`;
   });
 
   return {

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -1,5 +1,19 @@
 // i18n.js - 国际化模块
 
+// js/i18n.js 顶部添加转义函数
+window.escapeHTML = function(str) {
+  if (typeof str !== 'string') return str;
+  return str.replace(/[&<>'"]/g, 
+    tag => ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        "'": '&#39;',
+        '"': '&quot;'
+    }[tag] || tag)
+  );
+};
+
 // 当前语言
 let currentLanguage = localStorage.getItem('bizTrackLanguage') || 'en';
 

--- a/orders.js
+++ b/orders.js
@@ -288,10 +288,13 @@ function renderOrders(orders) {
       const translatedName = typeof translateProductName === 'function' ? translateProductName(order.itemName) : order.itemName;
       const translatedStatus = translateOrderStatus(order.orderStatus);
 
+      // 【新增】对 itemName 进行转义
+      const safeName = window.escapeHTML(translatedName);
+
       orderRow.innerHTML = `
         <td>${order.orderID}</td>
         <td>${order.orderDate}</td>
-        <td>${translatedName}</td>
+        <td>${safeName}</td>
         <td>${formattedPrice}</td>
         <td>${order.qtyBought}</td>
         <td>${formattedShipping}</td>

--- a/products.js
+++ b/products.js
@@ -214,11 +214,15 @@ function renderProducts(products) {
 
       const translatedName = typeof translateProductName === 'function' ? translateProductName(product.prodName) : product.prodName;
       const translatedCat = window.t(`products.${product.prodCat.toLowerCase()}`) || product.prodCat;
+      
+      // 【新增】对可能包含恶意代码的用户输入进行 XSS 转义
+      const safeName = window.escapeHTML(translatedName);
+      const safeDesc = window.escapeHTML(product.prodDesc);
 
       prodRow.innerHTML = `
           <td>${product.prodID}</td>
-          <td>${translatedName}</td>
-          <td>${product.prodDesc}</td>
+          <td>${safeName}</td>
+          <td>${safeDesc}</td>
           <td>${translatedCat}</td>
           <td>$${product.prodPrice.toFixed(2)}</td>
           <td>${product.prodSold}</td>


### PR DESCRIPTION
问题分析：
在 products.js、orders.js、finances.js 和 history.js 中，用户的输入（如 prodDesc、trNotes 等）直接通过模板字符串插入到 innerHTML 中渲染。如果用户输入恶意脚本（如 <script>...</script> 或 <img src="x" onerror="...">），会被直接执行。

修复方案：
在全局（例如 js/i18n.js 中）增加一个 HTML 转义的工具函数，并在渲染前对所有用户输入的字符串进行转义。

Before:
<img width="836" height="382" alt="截屏2026-04-27 23 02 44" src="https://github.com/user-attachments/assets/7fd961c0-f943-42a0-b14f-f24a97a6c79b" />
After:
<img width="822" height="524" alt="截屏2026-04-27 23 02 35" src="https://github.com/user-attachments/assets/b130aa58-7fc7-48a4-b64e-0499ba352655" />

<img width="509" height="602" alt="截屏2026-04-29 14 22 24" src="https://github.com/user-attachments/assets/0d18c954-07c7-4448-9812-479219ff8ca0" />



Part of #8

