### PR TITLE
Update one new rule for pop-up-cookies

### DIFF
--- a/cookie-banner.js
+++ b/cookie-banner.js
@@ -42,6 +42,7 @@ function initCookieBanner() {
     const rejectAll = window.t('privacy.rejectAll') || 'Reject All';
     const necessary = window.t('privacy.necessaryOnly') || 'Necessary Only';
     const acceptAll = window.t('privacy.acceptAll') || 'Accept All';
+    const close = window.t('privacy.close') || 'Close';
 
     banner.innerHTML = `
         <div style="flex-grow: 1; text-align: left; min-width: 250px;">
@@ -52,6 +53,7 @@ function initCookieBanner() {
             <button id="reject-all-btn" style="background-color: transparent; border: 1px solid #dc3545; color: #dc3545; padding: 6px 14px; border-radius: 4px; cursor: pointer; white-space: nowrap;" data-i18n="privacy.rejectAll">${escapeHTML(rejectAll)}</button>
             <button id="necessary-only-btn" style="background-color: transparent; border: 1px solid #6c757d; color: #6c757d; padding: 6px 14px; border-radius: 4px; cursor: pointer; white-space: nowrap;" data-i18n="privacy.necessaryOnly">${escapeHTML(necessary)}</button>
             <button id="accept-all-btn" style="background-color: #249672; color: white; border: none; padding: 7px 18px; border-radius: 4px; cursor: pointer; font-weight: bold; white-space: nowrap;" data-i18n="privacy.acceptAll">${escapeHTML(acceptAll)}</button>
+            <button id="close-banner-btn" style="background-color: transparent; border: 1px solid #6c757d; color: #6c757d; padding: 6px 14px; border-radius: 4px; cursor: pointer; white-space: nowrap;" data-i18n="privacy.close" aria-label="${escapeHTML(close)}">${escapeHTML(close)}</button>
         </div>
     `;
 
@@ -142,6 +144,12 @@ function initCookieBanner() {
         closeBanner();
     });
 
+    document.getElementById('close-banner-btn').addEventListener('click', () => {
+        // 关闭弹窗时默认选择"仅必要"选项
+        localStorage.setItem('bizTrack_cookieChoice', 'necessary_only');
+        closeBanner();
+    });
+
     // 键盘支持
     banner.addEventListener('keydown', (e) => {
         const focusableElements = getFocusableElements();
@@ -149,6 +157,8 @@ function initCookieBanner() {
         const lastFocusable = focusableElements[focusableElements.length - 1];
 
         if (e.key === 'Escape') {
+            // ESC键关闭时默认选择"仅必要"选项
+            localStorage.setItem('bizTrack_cookieChoice', 'necessary_only');
             closeBanner();
         } else if (e.key === 'Enter' || e.key === ' ') {
             // 当焦点在按钮上时，按下 Enter 或 Space 键触发按钮点击事件

--- a/i18n/index.js
+++ b/i18n/index.js
@@ -752,7 +752,7 @@ function initCookieBanner() {
   banner.style.cssText = `
     position: fixed; bottom: 0; left: 0; width: 100%;
     background: linear-gradient(135deg, #1976d2 0%, #2196f3 100%); color: white;
-    padding: 25px 30px; display: flex; flex-direction: row; justify-content: space-between;
+    padding: 25px 30px 25px 30px; display: flex; flex-direction: column; justify-content: center;
     align-items: center; flex-wrap: wrap; gap: 18px; z-index: 10001;
     box-shadow: 0 -8px 25px rgba(0,0,0,0.3);
     font-family: 'Lato', sans-serif; font-size: 16px; font-weight: 500; box-sizing: border-box;
@@ -765,16 +765,22 @@ function initCookieBanner() {
   const rejectAll = window.t('privacy.rejectAll') || 'Reject All';
   const necessary = window.t('privacy.necessaryOnly') || 'Necessary Only';
   const acceptAll = window.t('privacy.acceptAll') || 'Accept All';
+  const close = window.t('privacy.close') || 'Close';
 
   banner.innerHTML = `
-    <div style="flex-grow: 1; text-align: left; min-width: 250px;">
-      <span data-i18n="privacy.cookieMessage">${escapeHTML(msg)}</span>
-      <button id="privacy-policy-btn" style="background: rgba(255,255,255,0.2); border: none; color: white; text-decoration: underline; margin-left: 5px; font-weight: bold; padding: 4px 8px; cursor: pointer; border-radius: 4px; transition: background 0.2s;" data-i18n="privacy.policyLink">${escapeHTML(policy)}</button>
+    <div style="width: 100%; display: flex; justify-content: flex-end; padding-bottom: 10px;">
+      <button id="close-banner-btn" style="background: none; border: none; color: white; font-size: 14px; cursor: pointer; padding: 5px 10px; opacity: 0.8; transition: opacity 0.2s;" data-i18n="privacy.close" aria-label="${escapeHTML(close)}">${escapeHTML(close)}</button>
     </div>
-    <div style="display: flex; gap: 10px; flex-wrap: wrap;">
-      <button id="reject-all-btn" style="background-color: rgba(255,255,255,0.2); border: 1px solid rgba(255,255,255,0.5); color: white; padding: 8px 16px; border-radius: 6px; cursor: pointer; white-space: nowrap; font-weight: 500; transition: all 0.2s;" data-i18n="privacy.rejectAll">${escapeHTML(rejectAll)}</button>
-      <button id="necessary-only-btn" style="background-color: rgba(255,255,255,0.2); border: 1px solid rgba(255,255,255,0.5); color: white; padding: 8px 16px; border-radius: 6px; cursor: pointer; white-space: nowrap; font-weight: 500; transition: all 0.2s;" data-i18n="privacy.necessaryOnly">${escapeHTML(necessary)}</button>
-      <button id="accept-all-btn" style="background-color: white; color: #1976d2; border: none; padding: 8px 20px; border-radius: 6px; cursor: pointer; font-weight: bold; white-space: nowrap; box-shadow: 0 2px 8px rgba(0,0,0,0.15); transition: all 0.2s;" data-i18n="privacy.acceptAll">${escapeHTML(acceptAll)}</button>
+    <div style="width: 100%; display: flex; flex-direction: row; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 18px;">
+      <div style="flex-grow: 1; text-align: left; min-width: 250px;">
+        <span data-i18n="privacy.cookieMessage">${escapeHTML(msg)}</span>
+        <button id="privacy-policy-btn" style="background: rgba(255,255,255,0.2); border: none; color: white; text-decoration: underline; margin-left: 5px; font-weight: bold; padding: 4px 8px; cursor: pointer; border-radius: 4px; transition: background 0.2s;" data-i18n="privacy.policyLink">${escapeHTML(policy)}</button>
+      </div>
+      <div style="display: flex; gap: 10px; flex-wrap: wrap;">
+        <button id="reject-all-btn" style="background-color: rgba(255,255,255,0.2); border: 1px solid rgba(255,255,255,0.5); color: white; padding: 8px 16px; border-radius: 6px; cursor: pointer; white-space: nowrap; font-weight: 500; transition: all 0.2s;" data-i18n="privacy.rejectAll">${escapeHTML(rejectAll)}</button>
+        <button id="necessary-only-btn" style="background-color: rgba(255,255,255,0.2); border: 1px solid rgba(255,255,255,0.5); color: white; padding: 8px 16px; border-radius: 6px; cursor: pointer; white-space: nowrap; font-weight: 500; transition: all 0.2s;" data-i18n="privacy.necessaryOnly">${escapeHTML(necessary)}</button>
+        <button id="accept-all-btn" style="background-color: white; color: #1976d2; border: none; padding: 8px 20px; border-radius: 6px; cursor: pointer; font-weight: bold; white-space: nowrap; box-shadow: 0 2px 8px rgba(0,0,0,0.15); transition: all 0.2s;" data-i18n="privacy.acceptAll">${escapeHTML(acceptAll)}</button>
+      </div>
     </div>
   `;
   document.body.appendChild(banner);
@@ -853,13 +859,23 @@ function initCookieBanner() {
     closeBanner();
   });
 
-  // 键盘支持（不允许使用ESC关闭，必须强制用户做出选择）
+  document.getElementById('close-banner-btn').addEventListener('click', () => {
+    // 关闭弹窗时默认选择"仅必要"选项
+    localStorage.setItem('bizTrack_cookieChoice', 'necessary_only');
+    closeBanner();
+  });
+
+  // 键盘支持
   banner.addEventListener('keydown', (e) => {
     const focusableElements = getFocusableElements();
     const first = focusableElements[0];
     const last = focusableElements[focusableElements.length - 1];
 
-    if (e.key === 'Tab') {
+    if (e.key === 'Escape') {
+      // ESC键关闭时默认选择"仅必要"选项
+      localStorage.setItem('bizTrack_cookieChoice', 'necessary_only');
+      closeBanner();
+    } else if (e.key === 'Tab') {
       if (e.shiftKey && document.activeElement === first) {
         last.focus(); e.preventDefault();
       } else if (!e.shiftKey && document.activeElement === last) {

--- a/i18n/locales/en.js
+++ b/i18n/locales/en.js
@@ -356,6 +356,7 @@ export const en = {
     howWeUseItDesc: "Your data is strictly used to power the Dashboard analytics, generate tables, and provide you with business tracking functionalities.",
     cookieChoices: "3. Cookie choices",
     cookieChoicesDesc: "We only use 'Local Storage' to save your language preference and temporary session data. No tracking cookies are used.",
+    cookieDefaultNote: "If you do not make a selection or close the cookie banner, we will use only necessary cookies by default.",
     thirdParties: "4. Third parties",
     thirdPartiesDesc: "Your data is stored securely via Google Firebase. We do not sell or share your data with any advertising agencies.",
     contact: "5. Contact",

--- a/i18n/locales/zh-TW.js
+++ b/i18n/locales/zh-TW.js
@@ -369,6 +369,7 @@ export const zhTW = {
     howWeUseItDesc: "您的資料嚴格用於驅動儀表板分析、生成表格以及為您提供業務追蹤功能。",
     cookieChoices: "3. Cookie 選擇",
     cookieChoicesDesc: "我們僅使用「本地儲存」來儲存您的語言偏好和臨時會話資料。不使用任何追蹤型 Cookie。",
+    cookieDefaultNote: "如果您不進行選擇或關閉Cookie彈窗，我們將預設僅使用必要的Cookie。",
     thirdParties: "4. 第三方",
     thirdPartiesDesc: "您的資料通過 Google Firebase 安全儲存。我們絕不會將您的資料出售或分享給廣告機構。",
     contact: "5. 聯繫方式",

--- a/i18n/locales/zh.js
+++ b/i18n/locales/zh.js
@@ -370,6 +370,7 @@ export const zh = {
     howWeUseItDesc: "您的数据严格用于驱动仪表盘分析、生成表格以及为您提供业务跟踪功能。",
     cookieChoices: "3. Cookie 选择",
     cookieChoicesDesc: "我们仅使用“本地存储”来保存您的语言偏好和临时会话数据。不使用任何追踪型 Cookie。",
+    cookieDefaultNote: "如果您不进行选择或关闭Cookie弹窗，我们将默认仅使用必要的Cookie。",
     thirdParties: "4. 第三方",
     thirdPartiesDesc: "您的数据通过 Google Firebase 安全存储。我们绝不会将您的数据出售或分享给广告机构。",
     contact: "5. 联系方式",

--- a/privacy-modal.js
+++ b/privacy-modal.js
@@ -26,6 +26,7 @@ window.showPrivacyModal = function() {
     const howWeUseItDesc = window.t('privacy.howWeUseItDesc') || 'Your data is strictly used to power the Dashboard analytics, generate tables, and provide you with business tracking functionalities.';
     const cookieChoices = window.t('privacy.cookieChoices') || '3. Cookie choices';
     const cookieChoicesDesc = window.t('privacy.cookieChoicesDesc') || 'We only use Local Storage to save your language preference and temporary session data. No tracking cookies are used.';
+    const cookieDefaultNote = window.t('privacy.cookieDefaultNote') || 'If you do not make a selection or close the cookie banner, we will use only necessary cookies by default.';
     const thirdParties = window.t('privacy.thirdParties') || '4. Third parties';
     const thirdPartiesDesc = window.t('privacy.thirdPartiesDesc') || 'Your data is stored securely via Google Firebase. We do not sell or share your data with any advertising agencies.';
     const contact = window.t('privacy.contact') || '5. Contact';
@@ -49,6 +50,7 @@ window.showPrivacyModal = function() {
                 <article>
                     <h3>${cookieChoices}</h3>
                     <p>${cookieChoicesDesc}</p>
+                    <p style="font-size: 0.9em; color: #666; margin-top: 10px; padding: 10px; background-color: #f8f9fa; border-radius: 4px;">${cookieDefaultNote}</p>
                 </article>
                 <article>
                     <h3>${thirdParties}</h3>


### PR DESCRIPTION
New rule for cookie options added: When the banner is closed by the user, it will be regarded as selecting "only necessary" cookies.

<img width="3134" height="1773" alt="image" src="https://github.com/user-attachments/assets/4ee919be-ca9d-4467-bd4b-03c6007c0a08" />
<img width="1907" height="151" alt="image" src="https://github.com/user-attachments/assets/e8c081ee-f566-4803-82ef-8cd4b95b4a40" />
<img width="1906" height="146" alt="image" src="https://github.com/user-attachments/assets/77f38c1b-dee7-47c7-9f38-1231b904f252" />
<img width="3200" height="1307" alt="image" src="https://github.com/user-attachments/assets/8031a730-2912-4c0f-a400-6fb292a05b0d" />

