### PR TITLE
fix: improve sidebar behavior on narrow screens

### DIFF
--- a/script.js
+++ b/script.js
@@ -591,3 +591,6 @@ window.addEventListener('languageChanged', async () => {
     await loadDashboardSummary();
   }
 });
+
+window.openSidebar = openSidebar;
+window.closeSidebar = closeSidebar;

--- a/styles.css
+++ b/styles.css
@@ -2,9 +2,7 @@
     --black-color: #262626;
     --blue-color: #247BA0;
     --orange-color: #e49273;
-    --brown-color: #A37A74git add .\script.js .\styles.css
-git commit -m "fix: improve sidebar behavior on narrow screens"
-git status;
+    --brown-color: #A37A74;
     --light-blue: #6B8A9F;
     --light-orange: #F9E6D5;
     --white-color: #ffffff;
@@ -1074,40 +1072,9 @@ button:focus-visible {
   outline: 2px solid #007bff !important;
   outline-offset: 2px;
 }
-/* Fix sidebar display on narrow screens */
-@media (max-width: 768px) {
-    .sidebar {
-        display: none;
-        position: fixed;
-        top: 0;
-        left: 0;
-        bottom: auto;
-        width: 220px;
-        max-width: 80vw;
-        height: 100vh;
-        z-index: 9999;
-        background: var(--black-color);
-        flex-direction: column;
-        justify-content: flex-start;
-        align-items: stretch;
-        overflow-y: auto;
-    }
-
-    .sidebar[style*="display: block"],
-    .sidebar[style*="display: flex"] {
-        display: flex !important;
-    }
-
-    .main-content {
-        margin-left: 0;
-        width: 100%;
-        max-width: 100%;
-    }
-}
-/* Sidebar should work on tablet and narrow desktop widths */
+/* Narrow screen sidebar drawer fix */
 @media (max-width: 1200px) {
     .sidebar {
-        display: none;
         position: fixed;
         top: 0;
         left: 0;
@@ -1116,151 +1083,12 @@ button:focus-visible {
         height: 100vh;
         z-index: 9999;
         background: var(--black-color);
-        flex-direction: column;
-        justify-content: flex-start;
-        align-items: stretch;
         overflow-y: auto;
-    }
-
-    .sidebar[style*="display: block"],
-    .sidebar[style*="display: flex"] {
-        display: flex !important;
     }
 
     .main-content {
         margin-left: 0;
         width: 100%;
         max-width: 100%;
-    }
-}
-/* Responsive form and table layout for narrow screens */
-@media (max-width: 768px) {
-    .form-container {
-        width: 100%;
-        max-width: 100%;
-        box-sizing: border-box;
-        overflow-x: hidden;
-        padding: 16px;
-    }
-
-    .form-columns {
-        display: flex;
-        flex-direction: column;
-        align-items: stretch;
-        gap: 12px;
-        width: 100%;
-    }
-
-    .first-col,
-    .second-col,
-    .third-col,
-    .order-first-col,
-    .order-second-col,
-    .order-third-col {
-        width: 100%;
-        max-width: 100%;
-        box-sizing: border-box;
-    }
-
-    .form-container label,
-    .form-container b {
-        display: block;
-        width: 100%;
-        white-space: normal;
-        line-height: 1.3;
-    }
-
-    .form-container input[type="text"],
-    .form-container input[type="number"],
-    .form-container input[type="search"],
-    .form-container select {
-        width: 100%;
-        max-width: 100%;
-        box-sizing: border-box;
-    }
-
-    .button-col {
-        width: 100%;
-        display: flex;
-        flex-direction: column;
-        align-items: stretch;
-        gap: 10px;
-        margin-top: 8px;
-    }
-
-    .button-col button,
-    .button-col .btn,
-    .form-container button,
-    .form-container .btn {
-        width: 100%;
-        box-sizing: border-box;
-    }
-
-    .table-container {
-        width: 100%;
-        overflow-x: auto;
-    }
-
-    table {
-        min-width: 640px;
-    }
-}
-/* Responsive header layout for narrow screens */
-@media (max-width: 768px) {
-    .header-wrapper {
-        display: grid;
-        grid-template-columns: auto 1fr auto;
-        align-items: center;
-        gap: 10px;
-        padding: 12px 16px;
-    }
-
-    .header-wrapper h1,
-    .header-wrapper .page-title {
-        text-align: center;
-        font-size: 28px;
-        line-height: 1.2;
-        margin: 0;
-        min-width: 0;
-        word-break: keep-all;
-    }
-
-    .search-container {
-        max-width: 220px;
-    }
-
-    .language-switcher,
-    .language-switcher select {
-        max-width: 120px;
-    }
-}
-
-@media (max-width: 560px) {
-    .header-wrapper {
-        grid-template-columns: auto 1fr;
-        grid-template-areas:
-            "menu title"
-            "search language";
-    }
-
-    .menu-icon {
-        grid-area: menu;
-    }
-
-    .header-wrapper h1,
-    .header-wrapper .page-title {
-        grid-area: title;
-        font-size: 24px;
-    }
-
-    .search-container {
-        grid-area: search;
-        width: 100%;
-        max-width: none;
-    }
-
-    .language-switcher {
-        grid-area: language;
-        justify-self: end;
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -2,7 +2,9 @@
     --black-color: #262626;
     --blue-color: #247BA0;
     --orange-color: #e49273;
-    --brown-color: #A37A74;
+    --brown-color: #A37A74git add .\script.js .\styles.css
+git commit -m "fix: improve sidebar behavior on narrow screens"
+git status;
     --light-blue: #6B8A9F;
     --light-orange: #F9E6D5;
     --white-color: #ffffff;
@@ -1129,5 +1131,136 @@ button:focus-visible {
         margin-left: 0;
         width: 100%;
         max-width: 100%;
+    }
+}
+/* Responsive form and table layout for narrow screens */
+@media (max-width: 768px) {
+    .form-container {
+        width: 100%;
+        max-width: 100%;
+        box-sizing: border-box;
+        overflow-x: hidden;
+        padding: 16px;
+    }
+
+    .form-columns {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+        width: 100%;
+    }
+
+    .first-col,
+    .second-col,
+    .third-col,
+    .order-first-col,
+    .order-second-col,
+    .order-third-col {
+        width: 100%;
+        max-width: 100%;
+        box-sizing: border-box;
+    }
+
+    .form-container label,
+    .form-container b {
+        display: block;
+        width: 100%;
+        white-space: normal;
+        line-height: 1.3;
+    }
+
+    .form-container input[type="text"],
+    .form-container input[type="number"],
+    .form-container input[type="search"],
+    .form-container select {
+        width: 100%;
+        max-width: 100%;
+        box-sizing: border-box;
+    }
+
+    .button-col {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 10px;
+        margin-top: 8px;
+    }
+
+    .button-col button,
+    .button-col .btn,
+    .form-container button,
+    .form-container .btn {
+        width: 100%;
+        box-sizing: border-box;
+    }
+
+    .table-container {
+        width: 100%;
+        overflow-x: auto;
+    }
+
+    table {
+        min-width: 640px;
+    }
+}
+/* Responsive header layout for narrow screens */
+@media (max-width: 768px) {
+    .header-wrapper {
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
+        gap: 10px;
+        padding: 12px 16px;
+    }
+
+    .header-wrapper h1,
+    .header-wrapper .page-title {
+        text-align: center;
+        font-size: 28px;
+        line-height: 1.2;
+        margin: 0;
+        min-width: 0;
+        word-break: keep-all;
+    }
+
+    .search-container {
+        max-width: 220px;
+    }
+
+    .language-switcher,
+    .language-switcher select {
+        max-width: 120px;
+    }
+}
+
+@media (max-width: 560px) {
+    .header-wrapper {
+        grid-template-columns: auto 1fr;
+        grid-template-areas:
+            "menu title"
+            "search language";
+    }
+
+    .menu-icon {
+        grid-area: menu;
+    }
+
+    .header-wrapper h1,
+    .header-wrapper .page-title {
+        grid-area: title;
+        font-size: 24px;
+    }
+
+    .search-container {
+        grid-area: search;
+        width: 100%;
+        max-width: none;
+    }
+
+    .language-switcher {
+        grid-area: language;
+        justify-self: end;
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -1072,3 +1072,62 @@ button:focus-visible {
   outline: 2px solid #007bff !important;
   outline-offset: 2px;
 }
+/* Fix sidebar display on narrow screens */
+@media (max-width: 768px) {
+    .sidebar {
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        bottom: auto;
+        width: 220px;
+        max-width: 80vw;
+        height: 100vh;
+        z-index: 9999;
+        background: var(--black-color);
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: stretch;
+        overflow-y: auto;
+    }
+
+    .sidebar[style*="display: block"],
+    .sidebar[style*="display: flex"] {
+        display: flex !important;
+    }
+
+    .main-content {
+        margin-left: 0;
+        width: 100%;
+        max-width: 100%;
+    }
+}
+/* Sidebar should work on tablet and narrow desktop widths */
+@media (max-width: 1200px) {
+    .sidebar {
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 260px;
+        max-width: 82vw;
+        height: 100vh;
+        z-index: 9999;
+        background: var(--black-color);
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: stretch;
+        overflow-y: auto;
+    }
+
+    .sidebar[style*="display: block"],
+    .sidebar[style*="display: flex"] {
+        display: flex !important;
+    }
+
+    .main-content {
+        margin-left: 0;
+        width: 100%;
+        max-width: 100%;
+    }
+}


### PR DESCRIPTION
## Summary
Fixed responsive layout issues on narrow screens.

## Changes
- Fixed sidebar behavior on narrow desktop/tablet widths.
- Ensured the sidebar opens and closes correctly without relying on DevTools viewport changes.
- Preserved the sidebar logo and menu layout when opened.
- Improved Add/Edit form responsiveness on narrow screens.
- Reduced form input and button compression in Products, Orders, and Expenses forms.

## Testing
- Tested Dashboard, Products, Orders, Expenses, Balance, History, and About at narrow window widths.
- Verified the sidebar opens and closes correctly.
- Verified the BizTrack logo remains visible in the sidebar.
- Verified Add/Edit forms remain usable on narrow screens.
- Verified page content remains usable after closing the sidebar.

## Screenshots

### Narrow screen form layout
<img width="420" height="734" alt="{C571D1C9-982C-4635-9CDE-B0830F302C5C}" src="https://github.com/user-attachments/assets/672a8d45-0201-4be2-b7c6-6c696ce60bb4" />
hows the Products form remains usable on a narrow viewport.

### Narrow screen sidebar
Shows the sidebar opens correctly, keeps the BizTrack logo visible, and preserves the menu layout.
<img width="419" height="760" alt="{501281A8-48D4-4B44-8A15-9FB14FAF63CC}" src="https://github.com/user-attachments/assets/eb68a670-cbd2-43c5-a7a4-4ffc268d49cc" />

Related to #6