### PR TITLE
Add tests for Firebase replaceCollection and history fallback paths

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,3 @@
-# Jest 覆盖率 +（可选）上传到 Codecov
-# 需先在 GitHub: Settings → Secrets and variables → Actions 添加 CODECOV_TOKEN
-
 name: Test Coverage
 
 on:

--- a/__tests__/cookie-banner-dom-loading.test.js
+++ b/__tests__/cookie-banner-dom-loading.test.js
@@ -1,0 +1,36 @@
+/**
+ * Covers cookie-banner.js DOMContentLoaded listener (lines 198–200).
+ */
+beforeAll(() => {
+  window.t = jest.fn((key) => key);
+  window.showPrivacyModal = jest.fn();
+});
+
+describe('cookie-banner DOMContentLoaded registration', () => {
+  test('runs initCookieBanner when DOMContentLoaded fires under loading readyState', async () => {
+    jest.resetModules();
+    localStorage.clear();
+    document.body.innerHTML = '';
+
+    Object.defineProperty(document, 'readyState', {
+      configurable: true,
+      writable: true,
+      value: 'loading',
+    });
+
+    await import('../cookie-banner.js');
+
+    expect(document.getElementById('cookie-compliance-banner')).toBeNull();
+
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(document.getElementById('cookie-compliance-banner')).not.toBeNull();
+
+    Object.defineProperty(document, 'readyState', {
+      configurable: true,
+      writable: true,
+      value: 'complete',
+    });
+  });
+});

--- a/__tests__/cookie-banner.test.js
+++ b/__tests__/cookie-banner.test.js
@@ -222,4 +222,38 @@ describe('cookie-banner: initCookieBanner', () => {
       document.getElementById('accept-all-btn').click();
     }).not.toThrow();
   });
+
+  test('non-string cookie message from window.t skips HTML escaping branch', () => {
+    window.t = jest.fn((key) => {
+      if (key === 'privacy.cookieMessage') return 42;
+      return key;
+    });
+    window.initCookieBanner();
+    expect(document.getElementById('cookie-compliance-banner')).not.toBeNull();
+  });
+
+  test('enforceInertState marks nested descendants under body children', () => {
+    const section = document.createElement('section');
+    section.appendChild(document.createElement('div')).appendChild(document.createElement('span'));
+    document.body.appendChild(section);
+
+    window.initCookieBanner();
+    jest.advanceTimersByTime(150);
+
+    const nestedSpan = section.querySelector('span');
+    expect(nestedSpan.inert).toBe(true);
+  });
+
+  test('Enter on banner does not activate click when focus is not on a button', () => {
+    window.initCookieBanner();
+    const banner = document.getElementById('cookie-compliance-banner');
+    banner.focus();
+
+    const enterEvent = new KeyboardEvent('keydown', {
+      key: 'Enter', bubbles: true, cancelable: true
+    });
+    banner.dispatchEvent(enterEvent);
+
+    expect(localStorage.getItem('bizTrack_cookieChoice')).toBeNull();
+  });
 });

--- a/__tests__/firebase.test.js
+++ b/__tests__/firebase.test.js
@@ -191,6 +191,59 @@ describe('firebase: logActivity with active db', () => {
     expect(callArg.action).toBe('create');
     expect(callArg.recordId).toBe('1');
   });
+
+  test('uses empty recordId and default objects when optional args are nullish', async () => {
+    const mockAdd = jest.fn(() => Promise.resolve());
+    window.biztrackDb = {
+      collection: jest.fn(() => ({ add: mockAdd })),
+    };
+
+    await window.biztrackDbHelpers.logActivity('orders', 'delete', null, null, null);
+    const callArg = mockAdd.mock.calls[0][0];
+    expect(callArg.recordId).toBe('');
+    expect(callArg.entityId).toBe('');
+    expect(callArg.changedData).toEqual({});
+    expect(callArg.afterData).toEqual({});
+    expect(callArg.beforeData).toEqual({});
+  });
+});
+
+describe('firebase: replaceCollection early exit', () => {
+  test('returns without touching Firestore when biztrackDb is null', async () => {
+    window.biztrackDb = null;
+    await expect(
+      window.biztrackDbHelpers.syncCollection('products', [{ prodID: '1', name: 'A' }], 'prodID')
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('firebase: replaceCollection doc id branches', () => {
+  test('uses numeric index when idField is missing or empty on an item', async () => {
+    const mockDoc = jest.fn(() => ({ ref: {} }));
+    const mockSet = jest.fn();
+    const mockCommit = jest.fn(() => Promise.resolve());
+
+    window.biztrackDb = {
+      collection: jest.fn(() => ({
+        get: jest.fn(() => Promise.resolve({ forEach: jest.fn() })),
+        doc: mockDoc,
+      })),
+      batch: jest.fn(() => ({
+        delete: jest.fn(),
+        set: mockSet,
+        commit: mockCommit,
+      })),
+    };
+
+    await window.biztrackDbHelpers.syncCollection(
+      'products',
+      [{ prodName: 'no-id' }, { prodID: '', prodName: 'empty-id' }],
+      'prodID'
+    );
+
+    expect(mockDoc).toHaveBeenCalledWith('1');
+    expect(mockDoc).toHaveBeenCalledWith('2');
+  });
 });
 
 describe('firebase: replaceCollection snapshot iteration', () => {

--- a/__tests__/history.test.js
+++ b/__tests__/history.test.js
@@ -319,6 +319,45 @@ describe('loadHistory via window load event (Firebase mock)', () => {
     const rows = document.getElementById('historyTableBody').querySelectorAll('tr');
     expect(rows.length).toBeGreaterThan(0);
   });
+
+  test('fallback: only bulk-sync logs → second filter pass includes sync rows (lines 324-326)', async () => {
+    makeHistoryTbody();
+    const bulkOnly = { action: 'sync', entityType: 'products', entityId: 'all-products', clientTime: '2024-01-01' };
+    window.biztrackDb = {
+      collection: jest.fn(() => ({
+        where: jest.fn(() => ({ get: jest.fn().mockRejectedValue(new Error('needs index')) })),
+        orderBy: jest.fn(() => ({
+          limit: jest.fn(() => ({
+            get: jest.fn().mockResolvedValue({ docs: [{ data: () => bulkOnly }] }),
+          })),
+        })),
+      })),
+    };
+    window.dispatchEvent(new Event('load'));
+    await new Promise(r => setTimeout(r, 350));
+    const tbody = document.getElementById('historyTableBody');
+    expect(tbody.querySelectorAll('tr').length).toBeGreaterThan(0);
+    window.biztrackDb = null;
+  });
+
+  test('fallback: orderBy query also fails → inner catch (lines 327-328)', async () => {
+    makeHistoryTbody();
+    window.biztrackDb = {
+      collection: jest.fn(() => ({
+        where: jest.fn(() => ({ get: jest.fn().mockRejectedValue(new Error('filtered query failed')) })),
+        orderBy: jest.fn(() => ({
+          limit: jest.fn(() => ({
+            get: jest.fn().mockRejectedValue(new Error('fallback query failed')),
+          })),
+        })),
+      })),
+    };
+    window.dispatchEvent(new Event('load'));
+    await new Promise(r => setTimeout(r, 350));
+    const tbody = document.getElementById('historyTableBody');
+    expect(tbody.querySelector('tr')).not.toBeNull();
+    window.biztrackDb = null;
+  });
 });
 
 // ── formatTimestamp: timestamp.toDate() and invalid fallback branches ─────

--- a/__tests__/products-bootstrap-loading.test.js
+++ b/__tests__/products-bootstrap-loading.test.js
@@ -1,0 +1,55 @@
+/**
+ * Covers products.js boot path when document.readyState === "loading"
+ * (DOMContentLoaded listener branch instead of immediate init).
+ */
+beforeAll(() => {
+  window.t = jest.fn((key) => key);
+  window.biztrackDb = null;
+  window.biztrackDbHelpers = {
+    isReady: jest.fn(() => false),
+    syncCollection: jest.fn(),
+    logActivity: jest.fn(),
+  };
+  window.getCurrentLanguage = jest.fn(() => 'en');
+  window.addGuideButton = jest.fn();
+  global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+  global.URL.revokeObjectURL = jest.fn();
+  localStorage.clear();
+
+  const storedProducts = [
+    { prodID: 'PD001', prodName: 'Baseball caps', prodDesc: 'Peace embroidered cap', prodCat: 'Hats', prodPrice: 25.0, prodSold: 20 },
+  ];
+  localStorage.setItem('bizTrackProducts', JSON.stringify(storedProducts));
+  localStorage.setItem('bizTrackProductsCatalogVersion', 'full-16-v1');
+});
+
+describe('products.js bootstrap when readyState is loading', () => {
+  test('registers DOMContentLoaded and runs init after event', async () => {
+    jest.resetModules();
+
+    Object.defineProperty(document, 'readyState', {
+      configurable: true,
+      writable: true,
+      value: 'loading',
+    });
+
+    document.body.innerHTML = '';
+    const tbody = document.createElement('tbody');
+    tbody.id = 'tableBody';
+    document.body.appendChild(tbody);
+
+    await import('../products.js');
+
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(typeof window.renderProducts).toBe('function');
+    expect(document.getElementById('tableBody')).not.toBeNull();
+
+    Object.defineProperty(document, 'readyState', {
+      configurable: true,
+      writable: true,
+      value: 'complete',
+    });
+  });
+});

--- a/__tests__/products.test.js
+++ b/__tests__/products.test.js
@@ -74,6 +74,13 @@ describe('window.translateProductCategory (products.js)', () => {
     expect(typeof window.translateProductCategory).toBe('function');
   });
 
+  test('uses raw category when window.t is undefined but mapping key exists', () => {
+    const prev = window.t;
+    window.t = undefined;
+    expect(window.translateProductCategory('Hats')).toBe('Hats');
+    window.t = prev;
+  });
+
   test('returns original category when no translation found', () => {
     window.t.mockImplementation((key) => key);
     const result = window.translateProductCategory('Hats');
@@ -235,6 +242,46 @@ describe('window.renderProducts', () => {
     window.renderProducts([]);
     expect(tbody.querySelectorAll('tr').length).toBe(0);
   });
+
+  test('uses plain field values when translate helpers are absent', () => {
+    const tbody = document.getElementById('tableBody') || (() => {
+      const el = document.createElement('tbody');
+      el.id = 'tableBody';
+      document.body.appendChild(el);
+      return el;
+    })();
+
+    const prevName = window.translateProductName;
+    const prevDesc = window.translateProductDescription;
+    const prevCat = window.translateProductCategory;
+    delete window.translateProductName;
+    delete window.translateProductDescription;
+    delete window.translateProductCategory;
+
+    window.renderProducts(sampleProducts);
+
+    expect(tbody.querySelectorAll('tr').length).toBe(2);
+
+    window.translateProductName = prevName;
+    window.translateProductDescription = prevDesc;
+    window.translateProductCategory = prevCat;
+  });
+
+  test('uses default Edit/Delete button titles when window.t is undefined', () => {
+    const tbody = document.getElementById('tableBody') || (() => {
+      const el = document.createElement('tbody');
+      el.id = 'tableBody';
+      document.body.appendChild(el);
+      return el;
+    })();
+
+    const prevT = window.t;
+    window.t = undefined;
+    window.renderProducts(sampleProducts);
+    expect(tbody.innerHTML).toContain('Edit');
+    expect(tbody.innerHTML).toContain('Delete');
+    window.t = prevT;
+  });
 });
 
 // ── window.deleteProduct ──────────────────────────────────────────────────
@@ -257,6 +304,12 @@ describe('window.exportToCSV (products)', () => {
 
   test('runs without throwing for zh language', () => {
     window.getCurrentLanguage.mockReturnValue('zh');
+    expect(() => window.exportToCSV()).not.toThrow();
+    window.getCurrentLanguage.mockReturnValue('en');
+  });
+
+  test('uses Traditional Chinese csv filename when language is zhTW', () => {
+    window.getCurrentLanguage.mockReturnValue('zhTW');
     expect(() => window.exportToCSV()).not.toThrow();
     window.getCurrentLanguage.mockReturnValue('en');
   });


### PR DESCRIPTION
**What did I change?**
This PR adds and extends Jest unit/integration tests so more branches and edge paths are exercised under jsdom, without changing application behavior.

- __tests__/firebase.test.js: cover replaceCollection when biztrackDb is null; document id fallback when idField is missing or empty; logActivity with nullish optional payloads.
- __tests__/history.test.js: cover loadHistory fallback when only bulk-sync logs exist (second filter pass); inner catch when the orderBy fallback query also fails.
- __tests__/products.test.js / __tests__/products-bootstrap-loading.test.js: cover products.js init when document.readyState === "loading" (DOMContentLoaded path); extra cases for translateProductCategory, renderProducts fallbacks, exportToCSV filename for zhTW, and missing window.t.
- __tests__/cookie-banner.test.js / __tests__/cookie-banner-dom-loading.test.js: cover non-string copy from window.t, nested nodes for inert enforcement, Enter key when focus is not on a button, and DOMContentLoaded bootstrap.

**Why did I change it?**
To raise overall coverage (lines and especially branches) and make CI/coverage gates more stable by testing real control-flow branches (Firestore helpers, history queries, module bootstrap), instead of only happy paths.

**Where is the old-vs-new code?**

- Production code: effectively unchanged (this PR is tests only).
- Tests: under biztrack/__tests__/ — see files listed above; compare against main with: git diff main...feature/test-coverage -- biztrack/__tests__/

**What screenshots or preview links are included?**
<img width="930" height="465" alt="截屏2026-05-10 15 00 35" src="https://github.com/user-attachments/assets/b57b04f0-fba4-472c-afb2-787fc83499a7" />
