### PR TITLE
sync inventory pages from Firestore and prevent bootstrap overwriting…

### DIFF
--- a/__tests__/balance-chart-category-fallback.test.js
+++ b/__tests__/balance-chart-category-fallback.test.js
@@ -1,0 +1,53 @@
+/**
+ * Extends PRODUCT_CATEGORY_ORDER with an unknown category so balance.js
+ * renderSalesCategoryChart hits categoryKeyMap[key] || key.toLowerCase()… (lines 219–220).
+ */
+jest.mock('../analytics-service.js', () => {
+  const actual = jest.requireActual('../analytics-service.js');
+  return {
+    __esModule: true,
+    ...actual,
+    PRODUCT_CATEGORY_ORDER: [...actual.PRODUCT_CATEGORY_ORDER, '__ExtraCategory__'],
+  };
+});
+
+beforeAll(() => {
+  window.t = jest.fn((key) => key);
+  window.biztrackDb = null;
+  window.biztrackDbHelpers = {
+    isReady: jest.fn(() => false),
+    syncCollection: jest.fn(),
+    logActivity: jest.fn(),
+  };
+  window.getCurrentLanguage = jest.fn(() => 'en');
+  localStorage.clear();
+  window.ApexCharts = jest.fn().mockImplementation(() => ({
+    render: jest.fn(),
+    destroy: jest.fn(),
+    updateOptions: jest.fn(),
+  }));
+});
+
+beforeAll(async () => {
+  await import('../balance.js');
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('balance.js sales category chart with extra PRODUCT_CATEGORY_ORDER entry', () => {
+  test('DOMContentLoaded renders charts including fallback label branch for unknown category key', async () => {
+    ['balance-trend-chart', 'balance-margin-chart', 'balance-sales-category-chart', 'balance-expenses-chart'].forEach((id) => {
+      const el = document.createElement('div');
+      el.id = id;
+      document.body.appendChild(el);
+    });
+
+    window.ApexCharts.mockClear();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(window.ApexCharts).toHaveBeenCalled();
+  });
+});

--- a/__tests__/cookie-banner.test.js
+++ b/__tests__/cookie-banner.test.js
@@ -223,6 +223,28 @@ describe('cookie-banner: initCookieBanner', () => {
     }).not.toThrow();
   });
 
+  test('closeBanner clears inert flag on elements (line 114)', () => {
+    window.initCookieBanner();
+    jest.advanceTimersByTime(200);
+    const blocked = document.createElement('div');
+    blocked.id = 'blocked-node';
+    blocked.setAttribute('inert', '');
+    document.body.appendChild(blocked);
+    document.getElementById('accept-all-btn').click();
+    expect(blocked.inert).toBe(false);
+  });
+
+  test('escapeHTML maps special characters in translated banner strings', () => {
+    window.t = jest.fn((key) => {
+      if (key === 'privacy.cookieMessage') return 'A & B <script>';
+      return key;
+    });
+    window.initCookieBanner();
+    const span = document.querySelector('[data-i18n="privacy.cookieMessage"]');
+    expect(span.innerHTML).toContain('&amp;');
+    expect(span.innerHTML).toContain('&lt;');
+  });
+
   test('non-string cookie message from window.t skips HTML escaping branch', () => {
     window.t = jest.fn((key) => {
       if (key === 'privacy.cookieMessage') return 42;

--- a/__tests__/finances.test.js
+++ b/__tests__/finances.test.js
@@ -1,5 +1,7 @@
 // finances.js — test window-level functions exposed at module load time
 
+import * as dataService from '../data-service.js';
+
 beforeAll(() => {
   window.t = jest.fn((key) => key);
   window.biztrackDb = null;
@@ -572,7 +574,7 @@ describe('DOMContentLoaded: form submit listener and handleQuickAddOpen', () => 
     expect(() => document.dispatchEvent(new Event('DOMContentLoaded'))).not.toThrow();
   });
 
-  test('handleQuickAddOpen shows form when quickAdd=1 in URL (lines 174-178)', () => {
+  test('handleQuickAddOpen shows form when quickAdd=1 in URL (lines 174-178)', async () => {
     Object.defineProperty(window, 'location', {
       writable: true,
       value: { search: '?quickAdd=1', href: 'http://localhost/?quickAdd=1' },
@@ -588,7 +590,34 @@ describe('DOMContentLoaded: form submit listener and handleQuickAddOpen', () => 
     totalExp.id = 'total-expenses';
     document.body.appendChild(totalExp);
     document.dispatchEvent(new Event('DOMContentLoaded'));
+    await Promise.resolve();
     expect(form.style.display).toBe('block');
+  });
+
+  test('uses DEFAULT_EXPENSES when getDataWithFallback returns non-array (line 156)', async () => {
+    const spy = jest.spyOn(dataService, 'getDataWithFallback').mockResolvedValue({ notArray: true });
+    const form = document.createElement('form');
+    form.id = 'transaction-form';
+    document.body.appendChild(form);
+    const tbody = document.createElement('tbody');
+    tbody.id = 'tableBody';
+    document.body.appendChild(tbody);
+    const totalExp = document.createElement('div');
+    totalExp.id = 'total-expenses';
+    document.body.appendChild(totalExp);
+    const trDate = document.createElement('input');
+    trDate.id = 'tr-date';
+    document.body.appendChild(trDate);
+
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const stored = JSON.parse(localStorage.getItem('bizTrackTransactions') || '[]');
+    expect(Array.isArray(stored)).toBe(true);
+    expect(stored.length).toBeGreaterThan(0);
+
+    spy.mockRestore();
   });
 });
 

--- a/__tests__/firebase.test.js
+++ b/__tests__/firebase.test.js
@@ -133,6 +133,40 @@ describe('firebase: bootstrap from localStorage', () => {
     expect(mockCommit).toHaveBeenCalled();
   });
 
+  test('bootstrap pulls remote products into localStorage and does not overwrite cloud when remote exists', async () => {
+    const mockCommit = jest.fn(() => Promise.resolve());
+    const remoteProduct = { data: () => ({ prodID: 'FROM_CLOUD', prodName: 'Remote' }) };
+    window.biztrackDb = {
+      collection: jest.fn((collectionName) => ({
+        get: jest.fn(() => {
+          if (collectionName === 'products') {
+            return Promise.resolve({
+              forEach: (fn) => fn(remoteProduct),
+            });
+          }
+          return Promise.resolve({ forEach: jest.fn() });
+        }),
+        doc: jest.fn(() => ({})),
+        add: jest.fn(() => Promise.resolve()),
+      })),
+      batch: jest.fn(() => ({
+        delete: jest.fn(),
+        set: jest.fn(),
+        commit: mockCommit,
+      })),
+    };
+    localStorage.setItem('bizTrackProducts', JSON.stringify([{ prodID: 'STALE_LOCAL' }]));
+    localStorage.setItem('bizTrackOrders', JSON.stringify([]));
+    localStorage.setItem('bizTrackTransactions', JSON.stringify([]));
+
+    window.dispatchEvent(new Event('load'));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const cached = JSON.parse(localStorage.getItem('bizTrackProducts') || '[]');
+    expect(cached).toEqual([{ prodID: 'FROM_CLOUD', prodName: 'Remote' }]);
+    expect(mockCommit).not.toHaveBeenCalled();
+  });
+
   test('bootstrap syncs orders from localStorage', async () => {
     const { db, mockCommit } = makeMockDb();
     window.biztrackDb = db;
@@ -174,6 +208,24 @@ describe('firebase: bootstrap from localStorage', () => {
     };
     localStorage.setItem('bizTrackProducts', JSON.stringify([{ prodID: 'PD001' }]));
     expect(() => window.dispatchEvent(new Event('load'))).not.toThrow();
+  });
+
+  test('bootstrap continues when biztrackCollections entry is missing (line 94)', async () => {
+    const { db } = makeMockDb();
+    const savedCols = { ...window.biztrackCollections };
+    window.biztrackDb = db;
+    window.biztrackCollections = {
+      ...savedCols,
+      orders: undefined,
+    };
+    localStorage.setItem('bizTrackProducts', JSON.stringify([{ prodID: 'P1' }]));
+    localStorage.setItem('bizTrackOrders', JSON.stringify([{ orderID: '1001' }]));
+    localStorage.setItem('bizTrackTransactions', JSON.stringify([]));
+
+    expect(() => window.dispatchEvent(new Event('load'))).not.toThrow();
+    await new Promise((r) => setTimeout(r, 0));
+
+    window.biztrackCollections = savedCols;
   });
 });
 

--- a/__tests__/orders.test.js
+++ b/__tests__/orders.test.js
@@ -1,5 +1,7 @@
 // orders.js — test window-level functions exposed at module load time
 
+import * as dataService from '../data-service.js';
+
 beforeAll(() => {
   // Provide required globals before importing the module
   window.t = jest.fn((key) => key);
@@ -687,6 +689,18 @@ describe('DOMContentLoaded handler (orders)', () => {
     window.dispatchEvent(new CustomEvent('languageChanged'));
     await new Promise(r => setTimeout(r, 100));
     expect(true).toBe(true);
+  });
+
+  test('uses DEFAULT_ORDERS when getDataWithFallback returns non-array (line 383)', async () => {
+    const spy = jest.spyOn(dataService, 'getDataWithFallback').mockResolvedValue(null);
+    localStorage.removeItem('bizTrackOrders');
+    setupOrdersDOM();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await new Promise((r) => setTimeout(r, 100));
+    const stored = JSON.parse(localStorage.getItem('bizTrackOrders') || '[]');
+    expect(Array.isArray(stored)).toBe(true);
+    expect(stored.length).toBeGreaterThan(0);
+    spy.mockRestore();
   });
 });
 

--- a/__tests__/privacy-modal.test.js
+++ b/__tests__/privacy-modal.test.js
@@ -76,6 +76,21 @@ describe('privacy-modal: showPrivacyModal', () => {
     expect(focusSpy).toHaveBeenCalled();
   });
 
+  test('closing modal restores focus to the previously focused element (lines 80–81)', () => {
+    const trigger = document.createElement('button');
+    trigger.id = 'focus-me';
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    window.showPrivacyModal();
+    jest.advanceTimersByTime(100);
+    document.getElementById('privacy-modal-close').click();
+
+    expect(document.getElementById('privacy-modal')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
   test('Tab key wraps focus when on the last focusable element', () => {
     window.showPrivacyModal();
     const modal = document.getElementById('privacy-modal');

--- a/__tests__/products.test.js
+++ b/__tests__/products.test.js
@@ -595,4 +595,23 @@ describe('window.loadProductsFromStorage (lines 83-86)', () => {
     localStorage.setItem('bizTrackProductsCatalogVersion', 'v0.0.0-wrong');
     expect(() => window.loadProductsFromStorage()).not.toThrow();
   });
+
+  test('parses stored JSON when catalog version matches (line 88)', () => {
+    const row = {
+      prodID: 'ZZ99',
+      prodName: 'Snapbacks',
+      prodDesc: 'x',
+      prodCat: 'Hats',
+      prodPrice: 9,
+      prodSold: 3,
+    };
+    localStorage.setItem('bizTrackProducts', JSON.stringify([row]));
+    localStorage.setItem('bizTrackProductsCatalogVersion', 'full-16-v1');
+    expect(() => window.loadProductsFromStorage()).not.toThrow();
+    const tbody = document.createElement('tbody');
+    tbody.id = 'tableBody';
+    document.body.appendChild(tbody);
+    window.renderProducts(JSON.parse(localStorage.getItem('bizTrackProducts')));
+    expect(tbody.textContent).toContain('ZZ99');
+  });
 });

--- a/__tests__/script-chart-category-fallback.test.js
+++ b/__tests__/script-chart-category-fallback.test.js
@@ -1,0 +1,55 @@
+/**
+ * Extra category in PRODUCT_CATEGORY_ORDER covers script.js initializeChart
+ * categoryKeyMap fallback (lines 212–216).
+ */
+jest.mock('../analytics-service.js', () => {
+  const actual = jest.requireActual('../analytics-service.js');
+  return {
+    __esModule: true,
+    ...actual,
+    PRODUCT_CATEGORY_ORDER: [...actual.PRODUCT_CATEGORY_ORDER, '__Dash Category__'],
+  };
+});
+
+beforeAll(() => {
+  window.t = jest.fn((key) => key);
+  window.biztrackDb = null;
+  window.biztrackDbHelpers = {
+    isReady: jest.fn(() => false),
+    syncCollection: jest.fn(),
+    logActivity: jest.fn(),
+  };
+  window.getCurrentLanguage = jest.fn(() => 'en');
+  window.translateProductName = jest.fn((name) => name);
+  window.initI18n = jest.fn();
+  window.addGuideButton = jest.fn();
+  localStorage.clear();
+  window.ApexCharts = jest.fn().mockImplementation(() => ({
+    render: jest.fn(),
+    destroy: jest.fn(),
+    updateOptions: jest.fn(),
+  }));
+});
+
+beforeAll(async () => {
+  await import('../script.js');
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('script.js initializeChart with extra PRODUCT_CATEGORY_ORDER entry', () => {
+  test('bar chart uses fallback translation key for unknown category', async () => {
+    const bar = document.createElement('div');
+    bar.id = 'bar-chart';
+    document.body.appendChild(bar);
+    const donut = document.createElement('div');
+    donut.id = 'donut-chart';
+    document.body.appendChild(donut);
+
+    window.ApexCharts.mockClear();
+    await expect(window.initializeChart()).resolves.not.toThrow();
+    expect(window.ApexCharts).toHaveBeenCalled();
+  });
+});

--- a/finances.js
+++ b/finances.js
@@ -10,7 +10,7 @@ import {
     sortTableRowsByDataset
 } from './shared-utils.js';
 import { replaceParams } from './i18n/utils.js';
-import { DEFAULT_EXPENSES } from './data-service.js';
+import { DEFAULT_EXPENSES, getDataWithFallback } from './data-service.js';
 
 const escapeCSVValue = sanitizeCSVField;
 
@@ -131,7 +131,7 @@ function initTransactionDatePicker() {
     });
 }
 
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', async function() {
     // 初始化i18n
     if (typeof initI18n === 'function') {
         initI18n();
@@ -150,13 +150,11 @@ document.addEventListener('DOMContentLoaded', function() {
     // 初始化日期选择器
     initTransactionDatePicker();
 
-    const storedTransactions = localStorage.getItem("bizTrackTransactions");
-    if (storedTransactions) {
-        transactions = JSON.parse(storedTransactions);
-    } else {
-        transactions = DEFAULT_EXPENSES.map(transaction => ({ ...transaction }));
-        localStorage.setItem("bizTrackTransactions", JSON.stringify(transactions));
-    }
+    const merged = await getDataWithFallback("expenses", "bizTrackTransactions", DEFAULT_EXPENSES);
+    transactions = Array.isArray(merged)
+        ? merged.map((transaction) => ({ ...transaction }))
+        : DEFAULT_EXPENSES.map((transaction) => ({ ...transaction }));
+    localStorage.setItem("bizTrackTransactions", JSON.stringify(transactions));
 
     serialNumberCounter = transactions.length + 1;
     renderTransactions(transactions);

--- a/firebase.js
+++ b/firebase.js
@@ -82,22 +82,36 @@ async function bootstrapAllCollectionsFromLocalStorage() {
     return;
   }
 
-  const products = JSON.parse(localStorage.getItem("bizTrackProducts") || "[]");
-  const orders = JSON.parse(localStorage.getItem("bizTrackOrders") || "[]");
-  const expenses = JSON.parse(localStorage.getItem("bizTrackTransactions") || "[]");
+  const collections = [
+    { collectionKey: "products", localKey: "bizTrackProducts", idField: "prodID" },
+    { collectionKey: "orders", localKey: "bizTrackOrders", idField: "orderID" },
+    { collectionKey: "expenses", localKey: "bizTrackTransactions", idField: "trID" },
+  ];
 
-  try {
-    if (products.length) {
-      await window.biztrackDbHelpers.syncCollection("products", products, "prodID");
+  for (const { collectionKey, localKey, idField } of collections) {
+    try {
+      const firestoreName = window.biztrackCollections[collectionKey];
+      if (!firestoreName) continue;
+
+      const snapshot = await window.biztrackDb.collection(firestoreName).get();
+      const remoteData = [];
+      snapshot.forEach((doc) => {
+        remoteData.push(doc.data());
+      });
+
+      if (remoteData.length > 0) {
+        localStorage.setItem(localKey, JSON.stringify(remoteData));
+        continue;
+      }
+
+      const raw = localStorage.getItem(localKey);
+      const localItems = raw ? JSON.parse(raw) : [];
+      if (Array.isArray(localItems) && localItems.length > 0) {
+        await window.biztrackDbHelpers.syncCollection(collectionKey, localItems, idField);
+      }
+    } catch (error) {
+      console.error("Initial Firestore bootstrap failed (" + collectionKey + "):", error);
     }
-    if (orders.length) {
-      await window.biztrackDbHelpers.syncCollection("orders", orders, "orderID");
-    }
-    if (expenses.length) {
-      await window.biztrackDbHelpers.syncCollection("expenses", expenses, "trID");
-    }
-  } catch (error) {
-    console.error("Initial Firestore bootstrap failed:", error);
   }
 }
 

--- a/history.js
+++ b/history.js
@@ -185,22 +185,6 @@ function formatTimestamp(timestamp, fallback) {
   return "-";
 }
 
-function formatData(data) {
-  if (!data || (typeof data === "object" && Object.keys(data).length === 0)) {
-    return "-";
-  }
-
-  const lines = Object.entries(data).map(([key, value]) => {
-     const rawStringValue =
-      typeof value === "object" && value !== null ? JSON.stringify(value) : translateCellValue(key, value);
-      // 2. 【新增】进行 XSS 转义包装
-    const safeValue = window.escapeHTML(rawStringValue);
-    return `<div><span class="log-key">${translateFieldKey(key)}</span>: ${safeValue}</div>`;
-  });
-
-  return `<div class="log-data">${lines.join("")}</div>`;
-}
-
 function getPreferredFieldOrder(entity) {
   const fieldOrders = {
     products: ["prodID", "prodName", "prodDesc", "prodCat", "prodPrice", "prodSold"],

--- a/orders.js
+++ b/orders.js
@@ -10,7 +10,7 @@ import {
   downloadCSV,
   sortTableRowsByDataset
 } from './shared-utils.js';
-import { DEFAULT_ORDERS } from './data-service.js';
+import { DEFAULT_ORDERS, getDataWithFallback } from './data-service.js';
 
 // 翻译函数
 function translate(key, fallback, params = {}) {
@@ -374,19 +374,17 @@ window.exportToCSV = function() {
 };
 
 // ========== 初始化（修复时序，无重复） ==========
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', async function() {
   window.createOrderDatePicker();
 
-  const stored = localStorage.getItem("bizTrackOrders");
-  if (stored) {
-    orders = JSON.parse(stored);
-  } else {
-    orders = DEFAULT_ORDERS.map(order => ({ ...order }));
-    localStorage.setItem("bizTrackOrders", JSON.stringify(orders));
-  }
+  const merged = await getDataWithFallback("orders", "bizTrackOrders", DEFAULT_ORDERS);
+  orders = Array.isArray(merged)
+    ? merged.map((order) => ({ ...order }))
+    : DEFAULT_ORDERS.map((order) => ({ ...order }));
+  localStorage.setItem("bizTrackOrders", JSON.stringify(orders));
 
   window.renderOrders(orders);
-  window.syncOrdersToDb("sync", { orderID:"all-orders" });
+  window.syncOrdersToDb("sync", { orderID: "all-orders" });
   window.handleQuickAddOpen?.();
   window.addGuideButton?.('orders');
 

--- a/products.js
+++ b/products.js
@@ -9,7 +9,7 @@ import {
   downloadCSV,
   sortTableRowsByDataset
 } from './shared-utils.js';
-import { DEFAULT_PRODUCTS } from './data-service.js';
+import { DEFAULT_PRODUCTS, getDataWithFallback } from './data-service.js';
 
 // ========== 全局函数（必须挂到 window，给 onclick 用） ==========
 window.translateProductDescription = function(description) {
@@ -297,12 +297,17 @@ window.sortTable = function(col) {
 };
 
 // ========== 初始化（只执行一次，时序正确） ==========
-function init() {
+async function init() {
   document.getElementById("product-name")?.addEventListener("change", window.syncCategoryWithSelectedName);
-  loadProductsFromStorage();
+
+  const merged = await getDataWithFallback("products", "bizTrackProducts", DEFAULT_PRODUCTS);
+  products = Array.isArray(merged) ? merged.map((x) => ({ ...x })) : DEFAULT_PRODUCTS.map((x) => ({ ...x }));
+  localStorage.setItem("bizTrackProducts", JSON.stringify(products));
+  localStorage.setItem("bizTrackProductsCatalogVersion", PRODUCTS_CATALOG_VERSION);
+
   window.renderProducts(products);
   window.addEventListener('languageChanged', () => window.renderProducts(products));
-  window.syncProductsToDb("sync", {prodID:"all-products"});
+  window.syncProductsToDb("sync", { prodID: "all-products" });
   if (typeof window.addGuideButton === 'function') {
     window.addGuideButton('products');
   }


### PR DESCRIPTION
**What changed**

- products.js / orders.js / finances.js — On init, load data via getDataWithFallback(...) so each page matches Firestore when available, then persist to localStorage and render.
- firebase.js — Bootstrap: if the remote collection has documents, write them into localStorage and skip pushing local snapshots; only seed the cloud when the collection is empty and local data exists.
- history.js — Removed dead formatData() (unused).
- Tests — New/updated specs (e.g. balance-chart-category-fallback.test.js, script-chart-category-fallback.test.js, Firebase bootstrap edge cases, getDataWithFallback non-array fallbacks, cookie banner / privacy modal branches, products storage parse path); fixed finances quick-add test to await async init.

**Why**

- Bug: Edits in one browser did not show on another because those screens relied mainly on localStorage, while History came from Firestore—behavior looked inconsistent.
- Risk: The old bootstrap could replace Firestore with stale default local data on load.
- Quality: Higher line coverage and safer async tests reduce regressions.

**Where to review**

- products.js, orders.js, finances.js, data-service.js
- firebase.js
- history.js
- __tests__/*.test.js (see branch diff for full list)

**Screenshots / preview**
<img width="873" height="467" alt="截屏2026-05-12 22 32 02" src="https://github.com/user-attachments/assets/643f5792-4d62-4990-a65c-11fde006fc17" />
