### PR TITLE
modify-csv

### DIFF
--- a/__tests__/i18n-index.test.js
+++ b/__tests__/i18n-index.test.js
@@ -165,6 +165,19 @@ describe('window.translateProductName', () => {
     expect(window.translateProductName(null)).toBe(null);
     expect(window.translateProductName(undefined)).toBe(undefined);
   });
+
+  test('translates English product names when language is zhTW', () => {
+    window.changeLanguage('zhTW');
+    expect(window.translateProductName('Beanies')).toBe('無簷便帽');
+    window.changeLanguage('en');
+  });
+
+  test('maps Simplified Chinese product labels to Traditional when language is zhTW', () => {
+    window.changeLanguage('zhTW');
+    expect(window.translateProductName('无檐便帽')).toBe('無簷便帽');
+    expect(window.translateProductName('马克杯')).toBe('馬克杯');
+    window.changeLanguage('en');
+  });
 });
 
 // ── window.translateProductCategory ──────────────────────────────────────

--- a/__tests__/orders.test.js
+++ b/__tests__/orders.test.js
@@ -95,6 +95,15 @@ describe('window.translateOrderStatusForExport', () => {
     window.getCurrentLanguage.mockReturnValue('en');
   });
 
+  test('translates statuses to Traditional Chinese when lang is zhTW', () => {
+    window.getCurrentLanguage.mockReturnValue('zhTW');
+    expect(window.translateOrderStatusForExport('Pending')).toBe('待處理');
+    expect(window.translateOrderStatusForExport('Processing')).toBe('處理中');
+    expect(window.translateOrderStatusForExport('Shipped')).toBe('已出貨');
+    expect(window.translateOrderStatusForExport('Delivered')).toBe('已送達');
+    window.getCurrentLanguage.mockReturnValue('en');
+  });
+
   test('returns unknown status unchanged', () => {
     window.getCurrentLanguage.mockReturnValue('zh');
     expect(window.translateOrderStatusForExport('Unknown')).toBe('Unknown');
@@ -1093,9 +1102,19 @@ describe('exportToCSV language handling', () => {
     window.getCurrentLang = savedGetLang;
   });
 
+  test('uses zhTW headers when getCurrentLang returns zhTW', () => {
+    const savedGetLang = window.getCurrentLang;
+    window.getCurrentLang = jest.fn(() => 'zhTW');
+    window.translateOrderStatusForExport = window.translateOrderStatusForExport || jest.fn((s) => s);
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+    global.URL.revokeObjectURL = jest.fn();
+    expect(() => window.exportToCSV()).not.toThrow();
+    window.getCurrentLang = savedGetLang;
+  });
+
   test('falls back to en headers when lang is not in headers map (line 358 || branch)', () => {
     const savedGetLang = window.getCurrentLang;
-    window.getCurrentLang = jest.fn(() => 'zhTW');  // not in headers → || headers.en
+    window.getCurrentLang = jest.fn(() => 'fr');
     window.translateOrderStatusForExport = window.translateOrderStatusForExport || jest.fn((s) => s);
     global.URL.createObjectURL = jest.fn(() => 'blob:mock');
     global.URL.revokeObjectURL = jest.fn();

--- a/i18n/index.js
+++ b/i18n/index.js
@@ -650,7 +650,15 @@ window.translateProductName = function (name) {
   if (!name) return name;
   const map = translations[currentLanguage]?.productNames;
   if (!map) return name;
-  return map[name] || name;
+  if (map[name]) return map[name];
+  if (currentLanguage === 'zhTW') {
+    const zhMap = translations.zh?.productNames;
+    if (zhMap) {
+      const englishKey = Object.keys(zhMap).find((key) => zhMap[key] === name);
+      if (englishKey && map[englishKey]) return map[englishKey];
+    }
+  }
+  return name;
 };
 
 // 产品描述翻译

--- a/orders.js
+++ b/orders.js
@@ -27,7 +27,8 @@ window.getCurrentLang = function() {
 window.translateOrderStatusForExport = function(status) {
   const currentLanguage = window.getCurrentLang();
   const statuses = {
-    zh: { "Pending": "待处理", "Processing": "处理中", "Shipped": "已发货", "Delivered": "已送达" }
+    zh: { "Pending": "待处理", "Processing": "处理中", "Shipped": "已发货", "Delivered": "已送达" },
+    zhTW: { "Pending": "待處理", "Processing": "處理中", "Shipped": "已出貨", "Delivered": "已送達" }
   };
   return statuses[currentLanguage]?.[status] || status;
 };
@@ -353,7 +354,8 @@ window.exportToCSV = function() {
   const lang = window.getCurrentLang();
   const headers = {
     en: { orderID:"Order ID", orderDate:"Date", itemName:"Product", itemPrice:"Price", qtyBought:"Qty", shipping:"Shipping", taxes:"Taxes", orderTotal:"Total", orderStatus:"Status" },
-    zh: { orderID:"订单ID", orderDate:"日期", itemName:"产品", itemPrice:"价格", qtyBought:"数量", shipping:"运费", taxes:"税费", orderTotal:"总额", orderStatus:"状态" }
+    zh: { orderID:"订单ID", orderDate:"日期", itemName:"产品", itemPrice:"价格", qtyBought:"数量", shipping:"运费", taxes:"税费", orderTotal:"总额", orderStatus:"状态" },
+    zhTW: { orderID:"訂單ID", orderDate:"訂單日期", itemName:"商品名稱", itemPrice:"商品價格", qtyBought:"購買數量", shipping:"運費", taxes:"稅費", orderTotal:"訂單總額", orderStatus:"訂單狀態" }
   };
   const head = headers[lang] || headers.en;
   const data = orders.map(o => ({
@@ -369,7 +371,11 @@ window.exportToCSV = function() {
   }));
 
   const csv = generateCSV(data, head);
-  const filename = lang === 'zh' ? 'biztrack_订单表.csv' : 'biztrack_orders.csv';
+  const filename = lang === 'zhTW'
+    ? 'biztrack_訂單表.csv'
+    : lang === 'zh'
+      ? 'biztrack_订单表.csv'
+      : 'biztrack_orders.csv';
   downloadCSV(csv, filename);
 };
 


### PR DESCRIPTION
## Summary

Fixes incomplete Traditional Chinese output when exporting orders to CSV while the app language is set to **繁體中文 (zhTW)**.

Previously, CSV export in `zhTW` mode:
- Fell back to **English column headers** (e.g. `Order ID`, `Date`, `Status`)
- Left **order statuses untranslated** (`Pending`, `Delivered`, etc.)
- Used the **English filename** (`biztrack_orders.csv`) instead of the Traditional Chinese one
- Could show **mixed Simplified/Traditional product names** when order data contained Simplified Chinese labels

## Changes

### `orders.js`
- Add `zhTW` CSV header mappings (訂單ID, 商品名稱, 訂單狀態, etc.)
- Add `zhTW` order status translations for export (待處理, 處理中, 已出貨, 已送達)
- Use `biztrack_訂單表.csv` when language is `zhTW`

### `i18n/index.js`
- When language is `zhTW`, map Simplified Chinese product names to their Traditional Chinese equivalents via the existing English product key

### Tests
- Add/update unit tests for `zhTW` CSV export and product name translation
- Line coverage remains at **100%**